### PR TITLE
Add dataLayer Template and Fix tracking data overwriting dataLayer

### DIFF
--- a/app/code/community/GaugeInteractive/GoogleTagManager/Block/Tracking.php
+++ b/app/code/community/GaugeInteractive/GoogleTagManager/Block/Tracking.php
@@ -34,12 +34,12 @@ class GaugeInteractive_GoogleTagManager_Block_Tracking extends Mage_Checkout_Blo
         $js_items = array();
         foreach ($order->getAllVisibleItems() as $item) {
             $js_items[] = sprintf("{
-'sku': '%s',
-'name': '%s',
-'category': '%s',
-'price': '%s',
-'quantity': '%s'
-}",
+                'sku': '%s',
+                'name': '%s',
+                'category': '%s',
+                'price': '%s',
+                'quantity': '%s'
+                }",
                 $this->jsQuoteEscape($item->getSku()),
                 $this->jsQuoteEscape($item->getName()),
                 null, // Optional
@@ -48,21 +48,21 @@ class GaugeInteractive_GoogleTagManager_Block_Tracking extends Mage_Checkout_Blo
             );
         }
 
-        $result = sprintf("dataLayer = [{
-'transactionId': '%s',
-'transactionAffiliation': '%s',
-'transactionTotal': '%s',
-'transactionTax': '%s',
-'transactionShipping': '%s',
-'transactionProducts': [%s]
-}];",
-                $orderId,
-                $this->jsQuoteEscape(Mage::app()->getStore()->getFrontendName()),
-                $order->getBaseGrandTotal(),
-                $order->getBaseTaxAmount(),
-                $order->getBaseShippingAmount(),
-                implode(", ", $js_items)
-            );
+        $result = sprintf("dataLayer.push({
+            'transactionId': '%s',
+            'transactionAffiliation': '%s',
+            'transactionTotal': '%s',
+            'transactionTax': '%s',
+            'transactionShipping': '%s',
+            'transactionProducts': [%s]
+            });",
+            $orderId,
+            $this->jsQuoteEscape(Mage::app()->getStore()->getFrontendName()),
+            $order->getBaseGrandTotal(),
+            $order->getBaseTaxAmount(),
+            $order->getBaseShippingAmount(),
+            implode(", ", $js_items)
+        );
 
         return $result;
 

--- a/app/code/community/GaugeInteractive/GoogleTagManager/etc/config.xml
+++ b/app/code/community/GaugeInteractive/GoogleTagManager/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <GaugeInteractive_GoogleTagManager>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </GaugeInteractive_GoogleTagManager>
   </modules>
 

--- a/app/design/frontend/base/default/layout/gaugeinteractive_googletagmanager.xml
+++ b/app/design/frontend/base/default/layout/gaugeinteractive_googletagmanager.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <layout>
     <default>
+        <reference name="head">
+            <block type="core/template" name="google_tagmanager_datalayer" as="google_tagmanager_datalayer" before="-" template="googletagmanager/datalayer.phtml"/>
+        </reference>
         <reference name="after_body_start">
             <block type="googletagmanager/tm" name="google_tagmanager" as="google_tagmanager" template="googletagmanager/tm.phtml" />
         </reference>

--- a/app/design/frontend/base/default/template/googletagmanager/datalayer.phtml
+++ b/app/design/frontend/base/default/template/googletagmanager/datalayer.phtml
@@ -1,0 +1,11 @@
+<?php
+/*
+* Initiate the dataLayer before any other Google Tag Manager
+* related scripts run. This prevents overwriting dataLayer 
+* variables, or pushing data before it exists.
+*/
+?>
+
+<script type="text/javascript">
+    dataLayer = [];
+</script>


### PR DESCRIPTION
This minor version enhancement adds a template to initiate the `dataLayer` in the header before any other Tag Manager related code should run. This should help make it easier to incorporate other Tag Manager tools like Dynamic Remarketing which need to push to the `dataLayer`.

This update also fixes a bug with the tracking data overwriting the entire `dataLayer` in [Tracking.php](https://github.com/gaugeinteractive/GoogleTagManager_Magento/compare/feature/datalayer-initiator?expand=1#diff-dba2093389c7e8de8d17a53ee8d37115)